### PR TITLE
feat(gke): Allow up to 5 work node pool instances

### DIFF
--- a/230-gke-work-node-pool.tf
+++ b/230-gke-work-node-pool.tf
@@ -17,7 +17,7 @@ resource "google_container_node_pool" "work_node_pool" {
   }
   autoscaling {
     total_min_node_count = 0
-    total_max_node_count = 3
+    total_max_node_count = 5
     location_policy      = "ANY"
   }
 


### PR DESCRIPTION
When multiple environments are deployed at once, more than 3 instances are needed.